### PR TITLE
getting rid of old short logic

### DIFF
--- a/dags/sql/holding_returns_materialize.sql
+++ b/dags/sql/holding_returns_materialize.sql
@@ -149,7 +149,7 @@ returns AS(
         price_1 AS price,
         shares_traded,
         average_trade_price,
-        side * ((shares_1_adj * price_1 + dividends) / (shares_0 * price_0) - 1) AS return,
+        (shares_1_adj * price_1 + dividends) / (shares_0 * price_0) - 1 AS return,
         dividends,
         dividends_per_share
     FROM adjustments a


### PR DESCRIPTION
Getting rid of the first short logic which caused math problems down the line. 